### PR TITLE
Add the ability to specify a namespace seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ bootstrap(App, [provide(LockerConfig, {
   useValue: new LockerConfig('MyNamespace', Locker.DRIVERS.LOCAL)
 })), Locker])
 
+// LockerConfig also has an optional namespace separator (defaults to :)
+bootstrap(App, [provide(LockerConfig, {
+  useValue: new LockerConfig('MyNamespace', Locker.DRIVERS.LOCAL, '.')	// Values will be stored as **MyNamespace.myKey**
+})), Locker])
+
 class App {
   constructor(private locker: Locker) {}
 }

--- a/dist/locker.js
+++ b/dist/locker.js
@@ -220,13 +220,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	var LockerConfig = function LockerConfig() {
 	    var driverNamespace = arguments.length <= 0 || arguments[0] === undefined ? '' : arguments[0];
 	    var defaultDriverType = arguments.length <= 1 || arguments[1] === undefined ? exports.DRIVERS.SESSION : arguments[1];
-	    var namespaceSeperator = arguments.length <= 2 || arguments[2] === undefined ? ':' : arguments[2];
+	    var namespaceSeparator = arguments.length <= 2 || arguments[2] === undefined ? ':' : arguments[2];
 
 	    _classCallCheck(this, LockerConfig);
 
 	    this.driverNamespace = driverNamespace;
 	    this.defaultDriverType = defaultDriverType;
-	    this.namespaceSeperator = namespaceSeperator;
+	    this.namespaceSeparator = namespaceSeparator;
 	};
 	LockerConfig = __decorate([core_1.Injectable(), __param(0, core_1.Optional()), __param(1, core_1.Optional()), __param(2, core_1.Optional()), __metadata('design:paramtypes', [String, Driver_1.Driver, String])], LockerConfig);
 	exports.LockerConfig = LockerConfig;
@@ -237,9 +237,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        var driverNamespace = lockerConfig.driverNamespace;
 	        var defaultDriverType = lockerConfig.defaultDriverType;
-	        var namespaceSeperator = lockerConfig.namespaceSeperator;
+	        var namespaceSeparator = lockerConfig.namespaceSeparator;
 
-	        this.setNamespace(driverNamespace, namespaceSeperator);
+	        this.setNamespace(driverNamespace, namespaceSeparator);
 	        this.driver = defaultDriverType.isSupported() ? defaultDriverType : exports.DRIVERS.MEMORY;
 	    }
 
@@ -247,10 +247,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        key: "setNamespace",
 	        value: function setNamespace() {
 	            var namespace = arguments.length <= 0 || arguments[0] === undefined ? '' : arguments[0];
-	            var seperator = arguments.length <= 1 || arguments[1] === undefined ? ':' : arguments[1];
+	            var separator = arguments.length <= 1 || arguments[1] === undefined ? ':' : arguments[1];
 
 	            this.namespace = namespace;
-	            this.seperator = seperator;
+	            this.separator = separator;
 	        }
 	    }, {
 	        key: "useDriver",
@@ -258,7 +258,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            return new Locker_1({
 	                defaultDriverType: driver.isSupported() ? driver : exports.DRIVERS.MEMORY,
 	                driverNamespace: this.namespace,
-	                namespaceSeperator: this.seperator
+	                namespaceSeparator: this.separator
 	            });
 	        }
 	    }, {
@@ -294,7 +294,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }, {
 	        key: "_makeKey",
 	        value: function _makeKey(key) {
-	            return this.namespace ? "" + this.namespace + this.seperator + key : key;
+	            return this.namespace ? "" + this.namespace + this.separator + key : key;
 	        }
 	    }]);
 

--- a/dist/locker.js
+++ b/dist/locker.js
@@ -220,13 +220,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	var LockerConfig = function LockerConfig() {
 	    var driverNamespace = arguments.length <= 0 || arguments[0] === undefined ? '' : arguments[0];
 	    var defaultDriverType = arguments.length <= 1 || arguments[1] === undefined ? exports.DRIVERS.SESSION : arguments[1];
+	    var namespaceSeperator = arguments.length <= 2 || arguments[2] === undefined ? ':' : arguments[2];
 
 	    _classCallCheck(this, LockerConfig);
 
 	    this.driverNamespace = driverNamespace;
 	    this.defaultDriverType = defaultDriverType;
+	    this.namespaceSeperator = namespaceSeperator;
 	};
-	LockerConfig = __decorate([core_1.Injectable(), __param(0, core_1.Optional()), __param(1, core_1.Optional()), __metadata('design:paramtypes', [String, Driver_1.Driver])], LockerConfig);
+	LockerConfig = __decorate([core_1.Injectable(), __param(0, core_1.Optional()), __param(1, core_1.Optional()), __param(2, core_1.Optional()), __metadata('design:paramtypes', [String, Driver_1.Driver, String])], LockerConfig);
 	exports.LockerConfig = LockerConfig;
 	var Locker_1 = void 0;
 	var Locker = Locker_1 = function () {
@@ -235,8 +237,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        var driverNamespace = lockerConfig.driverNamespace;
 	        var defaultDriverType = lockerConfig.defaultDriverType;
+	        var namespaceSeperator = lockerConfig.namespaceSeperator;
 
-	        this.setNamespace(driverNamespace);
+	        this.setNamespace(driverNamespace, namespaceSeperator);
 	        this.driver = defaultDriverType.isSupported() ? defaultDriverType : exports.DRIVERS.MEMORY;
 	    }
 
@@ -244,15 +247,18 @@ return /******/ (function(modules) { // webpackBootstrap
 	        key: "setNamespace",
 	        value: function setNamespace() {
 	            var namespace = arguments.length <= 0 || arguments[0] === undefined ? '' : arguments[0];
+	            var seperator = arguments.length <= 1 || arguments[1] === undefined ? ':' : arguments[1];
 
 	            this.namespace = namespace;
+	            this.seperator = seperator;
 	        }
 	    }, {
 	        key: "useDriver",
 	        value: function useDriver(driver) {
 	            return new Locker_1({
 	                defaultDriverType: driver.isSupported() ? driver : exports.DRIVERS.MEMORY,
-	                driverNamespace: this.namespace
+	                driverNamespace: this.namespace,
+	                namespaceSeperator: this.seperator
 	            });
 	        }
 	    }, {
@@ -288,7 +294,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }, {
 	        key: "_makeKey",
 	        value: function _makeKey(key) {
-	            return this.namespace ? this.namespace + ":" + key : key;
+	            return this.namespace ? "" + this.namespace + this.seperator + key : key;
 	        }
 	    }]);
 

--- a/src/Locker.ts
+++ b/src/Locker.ts
@@ -18,7 +18,7 @@ export class LockerConfig {
   constructor(
     @Optional() public driverNamespace: string = '',
     @Optional() public defaultDriverType: Driver = DRIVERS.SESSION,
-	@Optional() public namespaceSeperator: string = ':'
+    @Optional() public namespaceSeperator: string = ':'
   ) {}
 }
 
@@ -39,14 +39,14 @@ export class Locker {
 
   public setNamespace(namespace = '', seperator = ':') {
     this.namespace = namespace
-	this.seperator = seperator
+    this.seperator = seperator
   }
 
   public useDriver(driver: Driver) {
     return new Locker({
       defaultDriverType: driver.isSupported() ? driver : DRIVERS.MEMORY,
       driverNamespace: this.namespace,
-	  namespaceSeperator: this.seperator
+      namespaceSeperator: this.seperator
     })
   }
 

--- a/src/Locker.ts
+++ b/src/Locker.ts
@@ -18,7 +18,7 @@ export class LockerConfig {
   constructor(
     @Optional() public driverNamespace: string = '',
     @Optional() public defaultDriverType: Driver = DRIVERS.SESSION,
-    @Optional() public namespaceSeperator: string = ':'
+    @Optional() public namespaceSeparator: string = ':'
   ) {}
 }
 
@@ -28,25 +28,25 @@ export class Locker {
 
   private driver: Driver
   private namespace: string
-  private seperator: string
+  private separator: string
 
   constructor(@Optional() lockerConfig: LockerConfig) {
-    const {driverNamespace, defaultDriverType, namespaceSeperator} = lockerConfig
+    const {driverNamespace, defaultDriverType, namespaceSeparator} = lockerConfig
 
-    this.setNamespace(driverNamespace, namespaceSeperator)
+    this.setNamespace(driverNamespace, namespaceSeparator)
     this.driver = defaultDriverType.isSupported() ? defaultDriverType : DRIVERS.MEMORY
   }
 
-  public setNamespace(namespace = '', seperator = ':') {
+  public setNamespace(namespace = '', separator = ':') {
     this.namespace = namespace
-    this.seperator = seperator
+    this.separator = separator
   }
 
   public useDriver(driver: Driver) {
     return new Locker({
       defaultDriverType: driver.isSupported() ? driver : DRIVERS.MEMORY,
       driverNamespace: this.namespace,
-      namespaceSeperator: this.seperator
+      namespaceSeparator: this.separator
     })
   }
 
@@ -75,6 +75,6 @@ export class Locker {
   }
 
   private _makeKey(key: string): string {
-    return this.namespace ? `${this.namespace}${this.seperator}${key}` : key
+    return this.namespace ? `${this.namespace}${this.separator}${key}` : key
   }
 }

--- a/src/Locker.ts
+++ b/src/Locker.ts
@@ -17,7 +17,8 @@ export const DRIVERS = {
 export class LockerConfig {
   constructor(
     @Optional() public driverNamespace: string = '',
-    @Optional() public defaultDriverType: Driver = DRIVERS.SESSION
+    @Optional() public defaultDriverType: Driver = DRIVERS.SESSION,
+	@Optional() public namespaceSeperator: string = ':'
   ) {}
 }
 
@@ -27,22 +28,25 @@ export class Locker {
 
   private driver: Driver
   private namespace: string
+  private seperator: string
 
   constructor(@Optional() lockerConfig: LockerConfig) {
-    const {driverNamespace, defaultDriverType} = lockerConfig
+    const {driverNamespace, defaultDriverType, namespaceSeperator} = lockerConfig
 
-    this.setNamespace(driverNamespace)
+    this.setNamespace(driverNamespace, namespaceSeperator)
     this.driver = defaultDriverType.isSupported() ? defaultDriverType : DRIVERS.MEMORY
   }
 
-  public setNamespace(namespace = '') {
+  public setNamespace(namespace = '', seperator = ':') {
     this.namespace = namespace
+	this.seperator = seperator
   }
 
   public useDriver(driver: Driver) {
     return new Locker({
       defaultDriverType: driver.isSupported() ? driver : DRIVERS.MEMORY,
-      driverNamespace: this.namespace
+      driverNamespace: this.namespace,
+	  namespaceSeperator: this.seperator
     })
   }
 
@@ -71,6 +75,6 @@ export class Locker {
   }
 
   private _makeKey(key: string): string {
-    return this.namespace ? `${this.namespace}:${key}` : key
+    return this.namespace ? `${this.namespace}${this.seperator}${key}` : key
   }
 }


### PR DESCRIPTION
When using the version of Angular locker designed for Angular 1 the values are saved using a single period `.` when using a namespace, however with the Angular 2 version the separator has changed thus breaking backwards compatibility which is important for hybrid apps.